### PR TITLE
5장. 서비스 추상화

### DIFF
--- a/sql/users_create.sql
+++ b/sql/users_create.sql
@@ -2,6 +2,7 @@ create table users (
     id varchar(10) primary key,
     name varchar(20) not null,
     password varchar(10) not null,
+    email varchar(30) not null,
     level tinyint not null,
     login int not null,
     recommend int not null

--- a/sql/users_create.sql
+++ b/sql/users_create.sql
@@ -1,5 +1,8 @@
 create table users (
-	id varchar(10) primary key,	
-	name varchar(20) not null,
-	password varchar(10) not null
+    id varchar(10) primary key,
+    name varchar(20) not null,
+    password varchar(10) not null,
+    level tinyint not null,
+    login int not null,
+    recommend int not null
 )

--- a/src/springbook/user/dao/UserDao.java
+++ b/src/springbook/user/dao/UserDao.java
@@ -16,4 +16,5 @@ public interface UserDao {
 
 	int getCount();
 
+    void update(User user);
 }

--- a/src/springbook/user/dao/UserDaoJdbc.java
+++ b/src/springbook/user/dao/UserDaoJdbc.java
@@ -2,6 +2,7 @@ package springbook.user.dao;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import springbook.user.domain.Level;
 import springbook.user.domain.User;
 
 import javax.sql.DataSource;
@@ -21,6 +22,9 @@ public class UserDaoJdbc implements UserDao {
                     user.setId(rs.getString("id"));
                     user.setName(rs.getString("name"));
                     user.setPassword(rs.getString("password"));
+                    user.setLevel(Level.valueOf(rs.getInt("level")));
+                    user.setLogin(rs.getInt("login"));
+                    user.setRecommend(rs.getInt("recommend"));
                     return user;
                 }
             };
@@ -32,10 +36,12 @@ public class UserDaoJdbc implements UserDao {
 
 
 	public void add(final User user) {
-            this.jdbcTemplate.update(
-                    "insert into users(id, name, password) values(?,?,?)",
-                    user.getId(), user.getName(), user.getPassword()
-            );
+        this.jdbcTemplate.update(
+                "insert into users(id, name, password, level, login, recommend) " +
+                "values(?,?,?,?,?,?)",
+                user.getId(), user.getName(), user.getPassword(),
+                user.getLevel().intValue(), user.getLogin(), user.getRecommend()
+        );
     }
 
 

--- a/src/springbook/user/dao/UserDaoJdbc.java
+++ b/src/springbook/user/dao/UserDaoJdbc.java
@@ -35,37 +35,46 @@ public class UserDaoJdbc implements UserDao {
     }
 
 
-	public void add(final User user) {
+    public void add(final User user) {
         this.jdbcTemplate.update(
                 "insert into users(id, name, password, level, login, recommend) " +
-                "values(?,?,?,?,?,?)",
+                        "values(?,?,?,?,?,?)",
                 user.getId(), user.getName(), user.getPassword(),
                 user.getLevel().intValue(), user.getLogin(), user.getRecommend()
         );
     }
 
 
-	public User get(String id) {
-		return this.jdbcTemplate.queryForObject(
-		        "select * from users where id = ?",
-                new Object[] {id},
+    public User get(String id) {
+        return this.jdbcTemplate.queryForObject(
+                "select * from users where id = ?",
+                new Object[]{id},
                 this.userMapper
-		);
+        );
     }
 
-	public void deleteAll() {
+    public void deleteAll() {
         this.jdbcTemplate.update("delete from users");
-	}
+    }
 
-	public int getCount() {
+    public int getCount() {
         return this.jdbcTemplate.queryForInt("select count(*) from users");
     }
 
-	public List<User> getAll() {
+    public List<User> getAll() {
         return this.jdbcTemplate.query(
                 "select * from users order by id",
                 this.userMapper
         );
-	}
+    }
 
+    public void update(User user) {
+        this.jdbcTemplate.update(
+            "update users set name = ?, password = ?, level = ?, login = ?, "+
+            "recommend = ? where id = ? ",
+            user.getName(), user.getPassword(),
+                user.getLevel().intValue(), user.getLogin(),
+                user.getRecommend(),
+				user.getId());
+    }
 }

--- a/src/springbook/user/dao/UserDaoJdbc.java
+++ b/src/springbook/user/dao/UserDaoJdbc.java
@@ -22,6 +22,7 @@ public class UserDaoJdbc implements UserDao {
                     user.setId(rs.getString("id"));
                     user.setName(rs.getString("name"));
                     user.setPassword(rs.getString("password"));
+                    user.setEmail(rs.getString("email"));
                     user.setLevel(Level.valueOf(rs.getInt("level")));
                     user.setLogin(rs.getInt("login"));
                     user.setRecommend(rs.getInt("recommend"));
@@ -35,11 +36,11 @@ public class UserDaoJdbc implements UserDao {
     }
 
 
-    public void add(final User user) {
+	public void add(User user) {
         this.jdbcTemplate.update(
-                "insert into users(id, name, password, level, login, recommend) " +
-                        "values(?,?,?,?,?,?)",
-                user.getId(), user.getName(), user.getPassword(),
+                "insert into users(id, name, password, email, level, login, recommend) " +
+                        "values(?,?,?,?,?,?,?)",
+                user.getId(), user.getName(), user.getPassword(), user.getEmail(),
                 user.getLevel().intValue(), user.getLogin(), user.getRecommend()
         );
     }
@@ -70,11 +71,11 @@ public class UserDaoJdbc implements UserDao {
 
     public void update(User user) {
         this.jdbcTemplate.update(
-            "update users set name = ?, password = ?, level = ?, login = ?, "+
-            "recommend = ? where id = ? ",
-            user.getName(), user.getPassword(),
-                user.getLevel().intValue(), user.getLogin(),
-                user.getRecommend(),
-				user.getId());
+            "update users set name = ?, password = ?, email = ?, " +
+                    "level = ?, login = ?, recommend = ? " +
+                 "where id = ? ",
+            user.getName(), user.getPassword(), user.getEmail(),
+            user.getLevel().intValue(), user.getLogin(), user.getRecommend(),
+            user.getId());
     }
 }

--- a/src/springbook/user/dao/UserDaoTest.java
+++ b/src/springbook/user/dao/UserDaoTest.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 import org.springframework.jdbc.support.SQLExceptionTranslator;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import springbook.user.domain.Level;
 import springbook.user.domain.User;
 
 import javax.sql.DataSource;
@@ -34,10 +35,10 @@ public class UserDaoTest {
 
 	@Before
 	public void setUp() {
-		this.user1 = new User("nathan", "안정원", "father");
-		this.user2 = new User("sunny", "현선", "mother");
-		this.user3 = new User("jane", "안재인", "daughter");
-        this.user4 = new User("junu", "안준우", "son");
+		this.user1 = new User("nathan", "안정원", "father", Level.BASIC, 10, 0);
+		this.user2 = new User("sunny", "현선", "mother", Level.SILVER, 55, 10);
+		this.user3 = new User("jane", "안재인", "daughter", Level.GOLD, 100, 40);
+        this.user4 = new User("junu", "안준우", "son", Level.GOLD, 101, 41);
 	}
 	
 	@Test
@@ -51,12 +52,10 @@ public class UserDaoTest {
 		assertThat(dao.getCount(), is(2));
 
 		User userget1 = dao.get(user1.getId());
-		assertThat(userget1.getName(), is(user1.getName()));
-		assertThat(userget1.getPassword(), is(user1.getPassword()));
+		checkSameUser(userget1, user1);
 
 		User userget2 = dao.get(user2.getId());
-		assertThat(userget2.getName(), is(user2.getName()));
-		assertThat(userget2.getPassword(), is(user2.getPassword()));
+		checkSameUser(userget2, user2);
 	}
 
     @Test(expected=EmptyResultDataAccessException.class)
@@ -117,6 +116,9 @@ public class UserDaoTest {
 		assertThat(user1.getId(), is(user2.getId()));
 		assertThat(user1.getName(), is(user2.getName()));
 		assertThat(user1.getPassword(), is(user2.getPassword()));
+		assertThat(user1.getLevel(), is(user2.getLevel()));
+		assertThat(user1.getLogin(), is(user2.getLogin()));
+		assertThat(user1.getRecommend(), is(user2.getRecommend()));
 	}
 
 	@Test(expected= DuplicateKeyException.class)

--- a/src/springbook/user/dao/UserDaoTest.java
+++ b/src/springbook/user/dao/UserDaoTest.java
@@ -35,10 +35,10 @@ public class UserDaoTest {
 
 	@Before
 	public void setUp() {
-		this.user1 = new User("nathan", "안정원", "father", Level.BASIC, 10, 0);
-		this.user2 = new User("sunny", "현선", "mother", Level.SILVER, 55, 10);
-		this.user3 = new User("jane", "안재인", "daughter", Level.GOLD, 100, 40);
-        this.user4 = new User("junu", "안준우", "son", Level.GOLD, 101, 41);
+		this.user1 = new User("nathan", "안정원", "father", "nathan@sunnygarden.net", Level.BASIC, 10, 0);
+		this.user2 = new User("sunny", "현선", "mother", "sunny@sunnygarden.net", Level.SILVER, 55, 10);
+		this.user3 = new User("jane", "안재인", "daughter", "jane@sunnygarden.net", Level.GOLD, 100, 40);
+        this.user4 = new User("junu", "안준우", "son", "junu@sunnygarden.net", Level.GOLD, 101, 41);
 	}
 	
 	@Test
@@ -116,6 +116,7 @@ public class UserDaoTest {
 		assertThat(user1.getId(), is(user2.getId()));
 		assertThat(user1.getName(), is(user2.getName()));
 		assertThat(user1.getPassword(), is(user2.getPassword()));
+        assertThat(user1.getEmail(), is(user2.getEmail()));
 		assertThat(user1.getLevel(), is(user2.getLevel()));
 		assertThat(user1.getLogin(), is(user2.getLogin()));
 		assertThat(user1.getRecommend(), is(user2.getRecommend()));
@@ -152,6 +153,7 @@ public class UserDaoTest {
 
 		user1.setName("안정원");
 		user1.setPassword("good");
+		user1.setEmail("user1@sunnygarden.net");
 		user1.setLevel(Level.GOLD);
 		user1.setLogin(1000);
 		user1.setRecommend(999);

--- a/src/springbook/user/dao/UserDaoTest.java
+++ b/src/springbook/user/dao/UserDaoTest.java
@@ -143,4 +143,25 @@ public class UserDaoTest {
 		}
 	}
 
+	@Test
+	public void update() {
+		dao.deleteAll();
+
+		dao.add(user1);     // 수정할 사용자
+		dao.add(user2);     // 수정하지 않을 사용자
+
+		user1.setName("안정원");
+		user1.setPassword("good");
+		user1.setLevel(Level.GOLD);
+		user1.setLogin(1000);
+		user1.setRecommend(999);
+		dao.update(user1);
+
+		User user1update = dao.get(user1.getId());
+		checkSameUser(user1, user1update);
+
+		User user2same = dao.get(user2.getId());
+		checkSameUser(user2, user2same);
+	}
+
 }

--- a/src/springbook/user/domain/Level.java
+++ b/src/springbook/user/domain/Level.java
@@ -1,0 +1,25 @@
+package springbook.user.domain;
+
+public enum Level {
+	BASIC(1), SILVER(2), GOLD(3);
+
+	private final int value;
+		
+	Level(int value) {
+		this.value = value;
+	}
+
+	public int intValue() {
+		return value;
+	}
+	
+	public static Level valueOf(int value) {
+		switch(value) {
+		case 1: return BASIC;
+		case 2: return SILVER;
+		case 3: return GOLD;
+		default: throw new AssertionError("Unknown value: " + value);
+		}
+	}
+}
+

--- a/src/springbook/user/domain/Level.java
+++ b/src/springbook/user/domain/Level.java
@@ -1,18 +1,25 @@
 package springbook.user.domain;
 
 public enum Level {
-	BASIC(1), SILVER(2), GOLD(3);
+	GOLD(3, null), SILVER(2, GOLD), BASIC(1, SILVER);
 
 	private final int value;
+    private final Level next;
+
 		
-	Level(int value) {
+	Level(int value, Level next) {
 		this.value = value;
+        this.next = next;
 	}
 
 	public int intValue() {
 		return value;
 	}
-	
+
+	public Level nextLevel() { 
+        return this.next;
+    }
+
 	public static Level valueOf(int value) {
 		switch(value) {
 		case 1: return BASIC;

--- a/src/springbook/user/domain/User.java
+++ b/src/springbook/user/domain/User.java
@@ -4,14 +4,21 @@ public class User {
     String id;
     String name;
     String password;
+	Level level;
+	int login;
+	int recommend;
 
 	public User() {
 	}
 
-	public User(String id, String name, String password) {
+	public User(String id, String name, String password, Level level,
+			int login, int recommend) {
 		this.id = id;
 		this.name = name;
 		this.password = password;
+		this.level = level;
+		this.login = login;
+		this.recommend = recommend;
 	}
 
     public String getId() {
@@ -34,4 +41,25 @@ public class User {
     public void setPassword(String password) {
         this.password = password;
     }
+
+	public Level getLevel() {
+		return level;
+	}
+	public void setLevel(Level level) {
+		this.level = level;
+	}
+
+	public int getLogin() {
+		return login;
+	}
+	public void setLogin(int login) {
+		this.login = login;
+	}
+
+	public int getRecommend() {
+		return recommend;
+	}
+	public void setRecommend(int recommend) {
+		this.recommend = recommend;
+	}
 }

--- a/src/springbook/user/domain/User.java
+++ b/src/springbook/user/domain/User.java
@@ -4,22 +4,26 @@ public class User {
     String id;
     String name;
     String password;
-	Level level;
-	int login;
-	int recommend;
+    String email;
+    Level level;
+    int login;
+    int recommend;
 
-	public User() {
-	}
+    public User() {
+    }
 
-	public User(String id, String name, String password, Level level,
-			int login, int recommend) {
-		this.id = id;
-		this.name = name;
-		this.password = password;
-		this.level = level;
-		this.login = login;
-		this.recommend = recommend;
-	}
+    public User(String id, String name, String password, String email,
+            Level level, int login, int recommend) {
+        super();
+        this.id = id;
+        this.name = name;
+        this.password = password;
+        this.email = email;
+        this.level = level;
+        this.login = login;
+        this.recommend = recommend;
+    }
+
 
     public String getId() {
         return id;
@@ -62,6 +66,13 @@ public class User {
 	public void setRecommend(int recommend) {
 		this.recommend = recommend;
 	}
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
 
     public void upgradeLevel() {
         Level nextLevel = this.level.nextLevel();

--- a/src/springbook/user/domain/User.java
+++ b/src/springbook/user/domain/User.java
@@ -62,4 +62,14 @@ public class User {
 	public void setRecommend(int recommend) {
 		this.recommend = recommend;
 	}
+
+    public void upgradeLevel() {
+        Level nextLevel = this.level.nextLevel();
+        if (nextLevel == null) {
+            throw new IllegalStateException(this.level + "은 업그레이드가 불가능합니다");
+        }
+        else {
+            this.level = nextLevel;
+        }
+	}
 }

--- a/src/springbook/user/domain/UserTest.java
+++ b/src/springbook/user/domain/UserTest.java
@@ -1,0 +1,38 @@
+package springbook.user.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class UserTest {
+	User user;
+	
+	@Before
+	public void setUp() {
+		user = new User();
+	}
+	
+	@Test()
+	public void upgradeLevel() {
+		Level[] levels = Level.values();
+		for(Level level : levels) {
+			if (level.nextLevel() == null) continue;
+			user.setLevel(level);
+			user.upgradeLevel();
+			assertThat(user.getLevel(), is(level.nextLevel()));
+		}
+	}
+	
+	@Test(expected=IllegalStateException.class)
+	public void cannotUpgradeLevel() {
+		Level[] levels = Level.values();
+		for(Level level : levels) {
+			if (level.nextLevel() != null) continue;
+			user.setLevel(level);
+			user.upgradeLevel();
+		}
+	}
+
+}

--- a/src/springbook/user/service/DummyMailSender.java
+++ b/src/springbook/user/service/DummyMailSender.java
@@ -1,0 +1,16 @@
+package springbook.user.service;
+
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+
+
+public class DummyMailSender implements MailSender {
+
+    public void send(SimpleMailMessage mailMessage) throws MailException {
+    }
+
+    public void send(SimpleMailMessage[] mailMessage) throws MailException {
+    }
+}
+

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -1,5 +1,6 @@
 package springbook.user.service;
 
+import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -26,11 +27,15 @@ public class UserService {
 	public static final int MIN_RECCOMEND_FOR_GOLD = 30;
 
 	private UserDao userDao;
-
+	private MailSender mailSender;
 	private PlatformTransactionManager transactionManager;
 
 	public void setUserDao(UserDao userDao) {
 		this.userDao = userDao;
+	}
+
+	public void setMailSender(MailSender mailSender) {
+		this.mailSender = mailSender;
 	}
 
 	public void setTransactionManager(PlatformTransactionManager transactionManager) {
@@ -73,8 +78,6 @@ public class UserService {
     }
 
 	private void sendUpgradeEMail(User user) {
-        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-        mailSender.setHost("mail.sunnygarden.net");
 
         SimpleMailMessage mailMessage = new SimpleMailMessage();
         mailMessage.setTo(user.getEmail());
@@ -82,7 +85,7 @@ public class UserService {
         mailMessage.setSubject("Upgrade 안내");
         mailMessage.setText("사용자님의 등급이 " + user.getLevel().name());
 
-        mailSender.send(mailMessage);
+        this.mailSender.send(mailMessage);
 	}
 
 	public void add(User user) {

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -1,10 +1,15 @@
 package springbook.user.service;
 
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import springbook.user.dao.UserDao;
 import springbook.user.domain.Level;
 import springbook.user.domain.User;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
 import java.util.List;
+
 
 public class UserService {
 	public static final int MIN_LOGCOUNT_FOR_SILVER = 50;
@@ -16,16 +21,35 @@ public class UserService {
 		this.userDao = userDao;
 	}
 
-	public void upgradeLevels() {
-        List<User> users = userDao.getAll();
+	private DataSource dataSource;  			
 
-        for(User user : users) {
-
-            if (canUpgradeLevel(user)) {
-                upgradeLevel(user);
-            }
-        }
+	public void setDataSource(DataSource dataSource) {
+		this.dataSource = dataSource;
 	}
+
+	public void upgradeLevels() throws Exception {
+		TransactionSynchronizationManager.initSynchronization();  
+		Connection c = DataSourceUtils.getConnection(dataSource); 
+		c.setAutoCommit(false);
+
+		try {									   
+            List<User> users = userDao.getAll();
+
+            for(User user : users) {
+                if (canUpgradeLevel(user)) {
+                    upgradeLevel(user);
+                }
+            }
+            c.commit();
+        } catch (Exception e) {
+            c.rollback();
+            throw e;
+        } finally {
+            DataSourceUtils.releaseConnection(c, dataSource);
+            TransactionSynchronizationManager.unbindResource(this.dataSource);
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
 
 	private boolean canUpgradeLevel(User user) {
 	    Level currentLevel = user.getLevel();
@@ -38,7 +62,7 @@ public class UserService {
         }
 	}
 
-	private void upgradeLevel(User user) {
+	protected void upgradeLevel(User user) {
         user.upgradeLevel();
         userDao.update(user);
     }

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -73,25 +73,16 @@ public class UserService {
     }
 
 	private void sendUpgradeEMail(User user) {
-        Properties props = new Properties();
-        props.put("mail.smtp.host", "mail.sunnygarden.net");
-        Session s = Session.getInstance(props, null);
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("mail.sunnygarden.net");
 
-        MimeMessage message = new MimeMessage(s);
-        try{
-            message.setFrom( new InternetAddress("admin@sunnygarden.net"));
-            message.addRecipient(Message.RecipientType.TO, new InternetAddress(user.getEmail()));
-            message.setSubject("Upgrade 안내");
-            message.setText("사용자님의 등급이 " + user.getLevel().name());
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+        mailMessage.setTo(user.getEmail());
+        mailMessage.setFrom("admin@sunnygarden.net");
+        mailMessage.setSubject("Upgrade 안내");
+        mailMessage.setText("사용자님의 등급이 " + user.getLevel().name());
 
-            Transport.send(message);
-        } catch (AddressException e) {
-            throw new RuntimeException();
-        } catch (MessagingException e) {
-            throw new RuntimeException();
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException();
-        }
+        mailSender.send(mailMessage);
 	}
 
 	public void add(User user) {

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -7,6 +7,8 @@ import springbook.user.domain.User;
 import java.util.List;
 
 public class UserService {
+	public static final int MIN_LOGCOUNT_FOR_SILVER = 50;
+	public static final int MIN_RECCOMEND_FOR_GOLD = 30;
 
 	private UserDao userDao;
 
@@ -29,14 +31,10 @@ public class UserService {
 	    Level currentLevel = user.getLevel();
 
 	    switch (currentLevel) {
-            case BASIC:
-                return (user.getLogin() >= 50);
-            case SILVER:
-                return (user.getRecommend() >= 30);
-            case GOLD:
-                return false;
-            default:
-                throw new IllegalArgumentException("Unknown Level: " + currentLevel);
+		case BASIC: return (user.getLogin() >= MIN_LOGCOUNT_FOR_SILVER); 
+		case SILVER: return (user.getRecommend() >= MIN_RECCOMEND_FOR_GOLD);
+		case GOLD: return false;
+		default: throw new IllegalArgumentException("Unknown Level: " + currentLevel); 
         }
 	}
 

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -20,24 +20,34 @@ public class UserService {
         for(User user : users) {
             Boolean changed = null;
 
-            if(user.getLevel() == Level.BASIC && user.getLogin() >= 50) {
-                user.setLevel(Level.SILVER);
-                changed = true;
-            } else if(user.getLevel() == Level.SILVER && user.getRecommend() >= 30) {
-                user.setLevel(Level.GOLD);
-                changed = true;
-            } else if(user.getLevel() == Level.GOLD) {
-                changed = false;
-            } else {
-                changed = false;
-            }
-
-            if(changed) {
-                userDao.update(user);
+            if (canUpgradeLevel(user)) {
+                upgradeLevel(user);
             }
         }
+	}
+
+	private boolean canUpgradeLevel(User user) {
+	    Level currentLevel = user.getLevel();
+
+	    switch (currentLevel) {
+            case BASIC:
+                return (user.getLogin() >= 50);
+            case SILVER:
+                return (user.getRecommend() >= 30);
+            case GOLD:
+                return false;
+            default:
+                throw new IllegalArgumentException("Unknown Level: " + currentLevel);
+        }
+	}
+
+	private void upgradeLevel(User user) {
+        if (user.getLevel() == Level.BASIC) user.setLevel(Level.SILVER);
+        else if (user.getLevel() == Level.SILVER) user.setLevel(Level.GOLD);
+
+        userDao.update(user);
     }
-	
+
 	public void add(User user) {
 		if (user.getLevel() == null) user.setLevel(Level.BASIC);
 		userDao.add(user);

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -18,7 +18,6 @@ public class UserService {
         List<User> users = userDao.getAll();
 
         for(User user : users) {
-            Boolean changed = null;
 
             if (canUpgradeLevel(user)) {
                 upgradeLevel(user);
@@ -42,9 +41,7 @@ public class UserService {
 	}
 
 	private void upgradeLevel(User user) {
-        if (user.getLevel() == Level.BASIC) user.setLevel(Level.SILVER);
-        else if (user.getLevel() == Level.SILVER) user.setLevel(Level.GOLD);
-
+        user.upgradeLevel();
         userDao.update(user);
     }
 

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -1,0 +1,42 @@
+package springbook.user.service;
+
+import springbook.user.dao.UserDao;
+import springbook.user.domain.Level;
+import springbook.user.domain.User;
+
+import java.util.List;
+
+public class UserService {
+
+	private UserDao userDao;
+
+	public void setUserDao(UserDao userDao) {
+		this.userDao = userDao;
+	}
+
+	public void upgradeLevels() {
+		List<User> users = userDao.getAll();
+
+		for(User user : users) {
+		    Boolean changed = null;
+
+		    if(user.getLevel() == Level.BASIC && user.getLogin() >= 50) {
+		        user.setLevel(Level.SILVER);
+		        changed = true;
+            } else if(user.getLevel() == Level.SILVER && user.getRecommend() >= 30) {
+		        user.setLevel(Level.GOLD);
+		        changed = true;
+            } else if( user.getLevel() == Level.GOLD) {
+		        changed = false;
+            } else {
+		        changed = false;
+            }
+
+		    if(changed) {
+		        userDao.update(user);
+            }
+		}
+	}
+
+}
+

--- a/src/springbook/user/service/UserService.java
+++ b/src/springbook/user/service/UserService.java
@@ -15,27 +15,32 @@ public class UserService {
 	}
 
 	public void upgradeLevels() {
-		List<User> users = userDao.getAll();
+        List<User> users = userDao.getAll();
 
-		for(User user : users) {
-		    Boolean changed = null;
+        for(User user : users) {
+            Boolean changed = null;
 
-		    if(user.getLevel() == Level.BASIC && user.getLogin() >= 50) {
-		        user.setLevel(Level.SILVER);
-		        changed = true;
+            if(user.getLevel() == Level.BASIC && user.getLogin() >= 50) {
+                user.setLevel(Level.SILVER);
+                changed = true;
             } else if(user.getLevel() == Level.SILVER && user.getRecommend() >= 30) {
-		        user.setLevel(Level.GOLD);
-		        changed = true;
-            } else if( user.getLevel() == Level.GOLD) {
-		        changed = false;
+                user.setLevel(Level.GOLD);
+                changed = true;
+            } else if(user.getLevel() == Level.GOLD) {
+                changed = false;
             } else {
-		        changed = false;
+                changed = false;
             }
 
-		    if(changed) {
-		        userDao.update(user);
+            if(changed) {
+                userDao.update(user);
             }
-		}
+        }
+    }
+	
+	public void add(User user) {
+		if (user.getLevel() == null) user.setLevel(Level.BASIC);
+		userDao.add(user);
 	}
 
 }

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -53,17 +53,22 @@ public class UserServiceTest {
 
 		userService.upgradeLevels();
 
-		checkLevel(users.get(0), Level.BASIC);
-		checkLevel(users.get(1), Level.SILVER);
-		checkLevel(users.get(2), Level.SILVER);
-		checkLevel(users.get(3), Level.GOLD);
-		checkLevel(users.get(4), Level.GOLD);
+        checkLevelUpgraded(users.get(0), false);
+        checkLevelUpgraded(users.get(1), true);
+        checkLevelUpgraded(users.get(2), false);
+        checkLevelUpgraded(users.get(3), true);
+        checkLevelUpgraded(users.get(4), false);
 	}
 
-	private void checkLevel(User user, Level expectedLevel) {
-	    User userUpdate = userDao.get(user.getId());
-	    assertThat(userUpdate.getLevel(), is(expectedLevel));
-    }
+	private void checkLevelUpgraded(User user, boolean upgraded) {
+        User userUpdate = userDao.get(user.getId());
+        if (upgraded) {
+            assertThat(userUpdate.getLevel(), is(user.getLevel().nextLevel()));
+        }
+        else {
+            assertThat(userUpdate.getLevel(), is(user.getLevel()));
+        }
+	}
 
 	@Test 
 	public void add() {

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 import springbook.user.dao.UserDao;
 import springbook.user.domain.Level;
 import springbook.user.domain.User;
@@ -27,7 +28,7 @@ public class UserServiceTest {
 
 	@Autowired 	UserService userService;
 	@Autowired  UserDao userDao;
-	@Autowired  DataSource dataSource;
+    @Autowired  PlatformTransactionManager transactionManager;
 
 	List<User> users;	// test fixture
 
@@ -95,9 +96,9 @@ public class UserServiceTest {
 	@Test
 	public void upgradeAllOrNothing() throws Exception {
 		UserService testUserService = new TestUserService(users.get(3).getId());  
-		testUserService.setUserDao(this.userDao); 
-		testUserService.setDataSource(this.dataSource);
-		
+		testUserService.setUserDao(this.userDao);
+		testUserService.setTransactionManager(transactionManager);
+
 		userDao.deleteAll();			  
 		for(User user : users) userDao.add(user);
 

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -10,13 +10,14 @@ import springbook.user.dao.UserDao;
 import springbook.user.domain.Level;
 import springbook.user.domain.User;
 
+import javax.sql.DataSource;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
-
+import static org.junit.Assert.fail;
 import static springbook.user.service.UserService.MIN_LOGCOUNT_FOR_SILVER;
 import static springbook.user.service.UserService.MIN_RECCOMEND_FOR_GOLD;
 
@@ -26,6 +27,7 @@ public class UserServiceTest {
 
 	@Autowired 	UserService userService;
 	@Autowired  UserDao userDao;
+	@Autowired  DataSource dataSource;
 
 	List<User> users;	// test fixture
 
@@ -49,7 +51,7 @@ public class UserServiceTest {
     }
 
     @Test
-	public void upgradeLevels() {
+	public void upgradeLevels() throws Exception {
 		userDao.deleteAll();
 		for(User user : users) userDao.add(user);
 
@@ -89,5 +91,43 @@ public class UserServiceTest {
 		assertThat(userWithLevelRead.getLevel(), is(userWithLevel.getLevel())); 
 		assertThat(userWithoutLevelRead.getLevel(), is(Level.BASIC));
 	}
+
+	@Test
+	public void upgradeAllOrNothing() throws Exception {
+		UserService testUserService = new TestUserService(users.get(3).getId());  
+		testUserService.setUserDao(this.userDao); 
+		testUserService.setDataSource(this.dataSource);
+		
+		userDao.deleteAll();			  
+		for(User user : users) userDao.add(user);
+
+		try {
+			testUserService.upgradeLevels();   
+			fail("TestUserServiceException expected"); 
+		}
+		catch(TestUserServiceException e) { 
+		}
+
+		checkLevelUpgraded(users.get(1), false);
+	}
+
+
+	static class TestUserService extends UserService {
+		private String id;
+
+		private TestUserService(String id) {  
+			this.id = id;
+		}
+
+		protected void upgradeLevel(User user) {
+			if (user.getId().equals(this.id)) throw new TestUserServiceException();  
+			super.upgradeLevel(user);  
+		}
+	}
+
+	static class TestUserServiceException extends RuntimeException {
+	}
+
+
 }
 

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -17,6 +17,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
+import static springbook.user.service.UserService.MIN_LOGCOUNT_FOR_SILVER;
+import static springbook.user.service.UserService.MIN_RECCOMEND_FOR_GOLD;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations="/test-applicationContext.xml")
@@ -30,11 +32,11 @@ public class UserServiceTest {
 	@Before
 	public void setUp() {
 		users = Arrays.asList(
-                new User("nathan", "안정원", "p1", Level.BASIC, 49, 0),
-                new User("sunny", "현선", "p2", Level.BASIC, 50, 0),
-                new User("jane", "안재인", "p3", Level.SILVER, 60, 29),
-                new User("junu", "안준우", "p4", Level.SILVER, 60, 30),
-                new User("nayoon", "현나윤", "p5", Level.GOLD, 100, 100)
+                new User("nathan", "안정원", "p1", Level.BASIC, MIN_LOGCOUNT_FOR_SILVER-1, 0),
+                new User("sunny", "현선", "p2", Level.BASIC, MIN_LOGCOUNT_FOR_SILVER, 0),
+                new User("jane", "안재인", "p3", Level.SILVER, 60, MIN_RECCOMEND_FOR_GOLD-1),
+                new User("junu", "안준우", "p4", Level.SILVER, 60, MIN_RECCOMEND_FOR_GOLD),
+                new User("nayoon", "현나윤", "p5", Level.GOLD, 100, Integer.MAX_VALUE)
 		);
 	}
 

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -1,0 +1,69 @@
+package springbook.user.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import springbook.user.dao.UserDao;
+import springbook.user.domain.Level;
+import springbook.user.domain.User;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations="/test-applicationContext.xml")
+public class UserServiceTest {
+
+	@Autowired 	UserService userService;
+	@Autowired  UserDao userDao;
+
+	List<User> users;	// test fixture
+
+	@Before
+	public void setUp() {
+		users = Arrays.asList(
+                new User("nathan", "안정원", "p1", Level.BASIC, 49, 0),
+                new User("sunny", "현선", "p2", Level.BASIC, 50, 0),
+                new User("jane", "안재인", "p3", Level.SILVER, 60, 29),
+                new User("junu", "안준우", "p4", Level.SILVER, 60, 30),
+                new User("nayoon", "현나윤", "p5", Level.GOLD, 100, 100)
+		);
+	}
+
+    @Test
+    /**
+     * 빈등록 설정이 잘 되어 빈이 생성되는지 확인
+     */
+    public void bean() {
+        assertThat(this.userService, is(notNullValue()));
+    }
+
+    @Test
+	public void upgradeLevels() {
+		userDao.deleteAll();
+		for(User user : users) userDao.add(user);
+
+		userService.upgradeLevels();
+
+		checkLevel(users.get(0), Level.BASIC);
+		checkLevel(users.get(1), Level.SILVER);
+		checkLevel(users.get(2), Level.SILVER);
+		checkLevel(users.get(3), Level.GOLD);
+		checkLevel(users.get(4), Level.GOLD);
+	}
+
+	private void checkLevel(User user, Level expectedLevel) {
+	    User userUpdate = userDao.get(user.getId());
+	    assertThat(userUpdate.getLevel(), is(expectedLevel));
+    }
+
+}
+

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -11,7 +11,6 @@ import springbook.user.dao.UserDao;
 import springbook.user.domain.Level;
 import springbook.user.domain.User;
 
-import javax.sql.DataSource;
 import java.util.Arrays;
 import java.util.List;
 
@@ -35,11 +34,11 @@ public class UserServiceTest {
 	@Before
 	public void setUp() {
 		users = Arrays.asList(
-                new User("nathan", "안정원", "p1", Level.BASIC, MIN_LOGCOUNT_FOR_SILVER-1, 0),
-                new User("sunny", "현선", "p2", Level.BASIC, MIN_LOGCOUNT_FOR_SILVER, 0),
-                new User("jane", "안재인", "p3", Level.SILVER, 60, MIN_RECCOMEND_FOR_GOLD-1),
-                new User("junu", "안준우", "p4", Level.SILVER, 60, MIN_RECCOMEND_FOR_GOLD),
-                new User("nayoon", "현나윤", "p5", Level.GOLD, 100, Integer.MAX_VALUE)
+                new User("nathan", "안정원", "p1", "nathan@sunnygarden.net", Level.BASIC, MIN_LOGCOUNT_FOR_SILVER-1, 0),
+                new User("sunny", "현선", "p2", "sunny@sunnygarden.net", Level.BASIC, MIN_LOGCOUNT_FOR_SILVER, 0),
+                new User("jane", "안재인", "p3", "jane@sunnygarden.net", Level.SILVER, 60, MIN_RECCOMEND_FOR_GOLD-1),
+                new User("junu", "안준우", "p4", "junu@sunnygarden.net", Level.SILVER, 60, MIN_RECCOMEND_FOR_GOLD),
+                new User("nayoon", "현나윤", "p5", "nayoon@sunnygarden.net", Level.GOLD, 100, Integer.MAX_VALUE)
 		);
 	}
 

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.MailSender;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -27,6 +28,7 @@ public class UserServiceTest {
 
 	@Autowired 	UserService userService;
 	@Autowired  UserDao userDao;
+    @Autowired  MailSender mailSender;
     @Autowired  PlatformTransactionManager transactionManager;
 
 	List<User> users;	// test fixture
@@ -96,7 +98,8 @@ public class UserServiceTest {
 	public void upgradeAllOrNothing() throws Exception {
 		UserService testUserService = new TestUserService(users.get(3).getId());  
 		testUserService.setUserDao(this.userDao);
-		testUserService.setTransactionManager(transactionManager);
+		testUserService.setTransactionManager(this.transactionManager);
+		testUserService.setMailSender(this.mailSender);
 
 		userDao.deleteAll();			  
 		for(User user : users) userDao.add(user);

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -4,7 +4,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.MailException;
 import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -12,6 +15,7 @@ import springbook.user.dao.UserDao;
 import springbook.user.domain.Level;
 import springbook.user.domain.User;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -53,9 +57,13 @@ public class UserServiceTest {
     }
 
     @Test
-	public void upgradeLevels() throws Exception {
+    @DirtiesContext         // Context의 DI 설정을 변경하여 테스트함을 알려줌.
+	public void upgradeLevels() {
 		userDao.deleteAll();
 		for(User user : users) userDao.add(user);
+
+		MockMailSender mockMailSender = new MockMailSender();  
+		userService.setMailSender(mockMailSender);
 
 		userService.upgradeLevels();
 
@@ -64,9 +72,29 @@ public class UserServiceTest {
         checkLevelUpgraded(users.get(2), false);
         checkLevelUpgraded(users.get(3), true);
         checkLevelUpgraded(users.get(4), false);
+
+		List<String> request = mockMailSender.getRequests();  
+		assertThat(request.size(), is(2));  
+		assertThat(request.get(0), is(users.get(1).getEmail()));  
+		assertThat(request.get(1), is(users.get(3).getEmail()));  
 	}
 
-	private void checkLevelUpgraded(User user, boolean upgraded) {
+    static class MockMailSender implements MailSender {
+        private List<String> requests = new ArrayList<String>();
+
+        public List<String> getRequests() {
+            return requests;
+        }
+
+        public void send(SimpleMailMessage mailMessage) throws MailException {
+            requests.add(mailMessage.getTo()[0]);
+        }
+
+        public void send(SimpleMailMessage[] mailMessage) throws MailException {
+        }
+    }
+
+    private void checkLevelUpgraded(User user, boolean upgraded) {
         User userUpdate = userDao.get(user.getId());
         if (upgraded) {
             assertThat(userUpdate.getLevel(), is(user.getLevel().nextLevel()));
@@ -74,7 +102,7 @@ public class UserServiceTest {
         else {
             assertThat(userUpdate.getLevel(), is(user.getLevel()));
         }
-	}
+    }
 
 	@Test 
 	public void add() {
@@ -95,7 +123,7 @@ public class UserServiceTest {
 	}
 
 	@Test
-	public void upgradeAllOrNothing() throws Exception {
+	public void upgradeAllOrNothing() {
 		UserService testUserService = new TestUserService(users.get(3).getId());  
 		testUserService.setUserDao(this.userDao);
 		testUserService.setTransactionManager(this.transactionManager);

--- a/src/springbook/user/service/UserServiceTest.java
+++ b/src/springbook/user/service/UserServiceTest.java
@@ -65,5 +65,22 @@ public class UserServiceTest {
 	    assertThat(userUpdate.getLevel(), is(expectedLevel));
     }
 
+	@Test 
+	public void add() {
+		userDao.deleteAll();
+
+		User userWithLevel = users.get(4);	  // GOLD 레벨
+		User userWithoutLevel = users.get(0);  
+		userWithoutLevel.setLevel(null);
+
+		userService.add(userWithLevel);	  
+		userService.add(userWithoutLevel);
+
+		User userWithLevelRead = userDao.get(userWithLevel.getId());
+		User userWithoutLevelRead = userDao.get(userWithoutLevel.getId());
+
+		assertThat(userWithLevelRead.getLevel(), is(userWithLevel.getLevel())); 
+		assertThat(userWithoutLevelRead.getLevel(), is(Level.BASIC));
+	}
 }
 

--- a/src/test-applicationContext.xml
+++ b/src/test-applicationContext.xml
@@ -21,9 +21,12 @@
         <property name="mailSender" ref="mailSender" />
     </bean>
 
+    <!-- mail 발송을 막기위해 구현체를 dummyMailSender로 변경
     <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
         <property name="host" value="mail.server.com" />
     </bean>
+    -->
+    <bean id="mailSender" class="springbook.user.service.DummyMailSender" />
 
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="dataSource" />

--- a/src/test-applicationContext.xml
+++ b/src/test-applicationContext.xml
@@ -14,4 +14,8 @@
 	<bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
 		<property name="dataSource" ref="dataSource" />
 	</bean>
+
+	<bean id="userService" class="springbook.user.service.UserService">
+		<property name="userDao" ref="userDao" />
+	</bean>
 </beans>

--- a/src/test-applicationContext.xml
+++ b/src/test-applicationContext.xml
@@ -4,19 +4,23 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans 
 						http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-	<bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
-		<property name="driverClass" value="com.mysql.jdbc.Driver" />
-		<property name="url" value="jdbc:mysql://localhost/springbook?characterEncoding=UTF-8" />
-		<property name="username" value="spring" />
-		<property name="password" value="book" />
-	</bean>
+    <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+        <property name="driverClass" value="com.mysql.jdbc.Driver" />
+        <property name="url" value="jdbc:mysql://localhost/springbook?characterEncoding=UTF-8" />
+        <property name="username" value="spring" />
+        <property name="password" value="book" />
+    </bean>
 	
-	<bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
-		<property name="dataSource" ref="dataSource" />
-	</bean>
+    <bean id="userDao" class="springbook.user.dao.UserDaoJdbc">
+        <property name="dataSource" ref="dataSource" />
+    </bean>
 
-	<bean id="userService" class="springbook.user.service.UserService">
-		<property name="userDao" ref="userDao" />
-		<property name="dataSource" ref="dataSource" />
-	</bean>
+    <bean id="userService" class="springbook.user.service.UserService">
+        <property name="userDao" ref="userDao" />
+        <property name="transactionManager" ref="transactionManager" />
+    </bean>
+
+    <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+        <property name="dataSource" ref="dataSource" />
+    </bean>
 </beans>

--- a/src/test-applicationContext.xml
+++ b/src/test-applicationContext.xml
@@ -18,6 +18,11 @@
     <bean id="userService" class="springbook.user.service.UserService">
         <property name="userDao" ref="userDao" />
         <property name="transactionManager" ref="transactionManager" />
+        <property name="mailSender" ref="mailSender" />
+    </bean>
+
+    <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
+        <property name="host" value="mail.server.com" />
     </bean>
 
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">

--- a/src/test-applicationContext.xml
+++ b/src/test-applicationContext.xml
@@ -17,5 +17,6 @@
 
 	<bean id="userService" class="springbook.user.service.UserService">
 		<property name="userDao" ref="userDao" />
+		<property name="dataSource" ref="dataSource" />
 	</bean>
 </beans>


### PR DESCRIPTION
주요내용

 • 비즈니스 로직을 담은 코드는 데이터 액세스 로직을 담은 코드와 깔끔하게 분리되는 것이 바람직하다. 비즈니스 로직 코드 또한 내부적으로 책임과 역할에 따라서 깔끔하게 메소드로 정리 되어야한다.  
 • 이를 위해서는 DAO의 기술 변화에 서비스 계층의 코드가 영향을 받지 않도록 인터페이스와 DI를 잘 활용해서 결합도를 낮춰줘야 한다.
 • DAO를 사용히는 비즈니스 로직에는 단위 작업을 보장해주는 트랜잭션이 필요하다.
 • 트랜잭션의 시작과 종료를 지정하는 일을 트랜잭션 경계설정이라고 한다. 트랜잭션 경계설정은 주로 비즈니스 로직 안에서 일어나는 경우가 많다.
 • 시작된 트랜잭션 정보를 담은 오브젝트를 따라미터로 DAO에 전달하는 방법은 매우 비효율적이기 때문에 스프링이 제공하는 트랜잭션 동기화 기법을 활용하는 것이 편리하다. • 자바에서 사용되는 트랜잭션 API의 종류와 방법은 다양하다 환경과 서버에 따라서 트랜잭션 방법이 변경되변 경계설정 코드도 함께 변경돼야 한다.  
 • 트랜잭션 방법에 따라 비즈니스 로직을 담은 묘드가 함께 변경되면 단일 책임 원칙에 위배되며， DAO가 사용하는 특정 기술에 대해 강한 결합을 만들어낸다.
 • 트랜잭션 경계설정 코드가 비즈니스 로직 코드에 영향을 주지 않게 하려면 스프링이 제공하는 트랜잭션 서비스 추상화를 이용하면 된다.
 • 서비스 추상회는 로우레벨의 트랜잭션 기술과 API의 변화에 상관없이 일관된 API를 가진 추상화 계층을 도입한다.  
 • 서비스 추상화는 테스트하기 어려운 lavaMail 같은 기술에도 적용할 수 있다. 테스트를 편리하게 작성하도록 도외주는 것만으로도 서비스 추상화는 가치가 었다.  
 • 태스트 대상이 사용하는 의존 오브젝트를 대체할 수 있도록 만든 오브젝트를 테스트 대역이라고한다.  
 • 태스트 대역은 테스트 대상 오브젝트가 원활하게 동작할 수 있도록 도우면서 태스트를 위해 간접적인 정보를 제공해주기도 한다.  
 • 태스트 대역 중에서 테스트 대상으로부터 전달받은 정보를 검증할 수 있도록 설계된 것을 목오브젝트라고한다.